### PR TITLE
fix(protocol): handle protocol specially on Windows

### DIFF
--- a/main/preload.ts
+++ b/main/preload.ts
@@ -14,6 +14,7 @@ const electronAPI: IElectronAPI = {
     openFile: (path) => ipcRenderer.invoke('data:open', path),
     closeFile: () => ipcRenderer.invoke('data:close'),
     loadChapter: (id) => ipcRenderer.invoke('data:load-chapter', id),
+    platform: process.platform,
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/main/types.d.ts
+++ b/main/types.d.ts
@@ -14,6 +14,7 @@ export interface IElectronAPI {
     openFile: (path: string) => Promise<EpubBook>
     closeFile: () => Promise<void>
     loadChapter: (id: string) => Promise<string>
+    platform: NodeJS.Platform
 }
 
 declare global {

--- a/renderer/pages/reading/Content.tsx
+++ b/renderer/pages/reading/Content.tsx
@@ -31,7 +31,13 @@ const processHtml = (htmlString: string) => {
             .map((a) => [a, t.getAttribute(a)] as [string, string | null])
             .find(([_, a]) => a !== null) ?? null
         if (!src) continue
-        t.setAttribute(src[0], `moyurd://${src[1]}`)
+        if (window.electronAPI.platform == 'win32') {
+            // `moyurd:///C:\path\to\file`
+            t.setAttribute(src[0], `moyurd:///${src[1]}`)
+        } else {
+            // `moyurd:///path/to/file`
+            t.setAttribute(src[0], `moyurd://${src[1]}`)
+        }
     }
 
     // remove inline style


### PR DESCRIPTION
#1 

Windows absolute paths require a leading "/"
  e.g. `moyurd:///C:\path\to\file` => `moyurd:// + / + C:\path\to\file`

Unix-like systems only need protocol + path
  e.g. `moyurd:///path/to/file` => `moyurd:// + /path/to/file`